### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.3
+python-3.9.5


### PR DESCRIPTION
 Requested runtime (python-3.8.3) is not available for this stack (heroku-20).
